### PR TITLE
Overflow mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Configurable overflow strategy (can now block or drop the messages silently).
 * Configurable name of the background thread.
 
 ## 2.2.0 - 2017-07-23

--- a/lib.rs
+++ b/lib.rs
@@ -89,8 +89,7 @@ impl Serializer for ToSendSerializer {
         Ok(())
     }
     fn emit_unit(&mut self, key: Key) -> slog::Result {
-        let val = ();
-        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, ()))));
         Ok(())
     }
     fn emit_none(&mut self, key: Key) -> slog::Result {
@@ -236,7 +235,7 @@ where
         AsyncCoreBuilder {
             chan_size: 128,
             blocking: false,
-            drain: drain,
+            drain,
             thread_name: None,
         }
     }
@@ -340,7 +339,7 @@ where
             },
             AsyncGuard {
                 join: Some(join),
-                tx: tx,
+                tx,
             },
         )
     }
@@ -612,7 +611,7 @@ where
         let (core, guard) = self.core.build_with_guard();
         (
             Async {
-                core: core,
+                core,
                 dropped: AtomicUsize::new(0),
                 inc_dropped: self.inc_dropped,
             },


### PR DESCRIPTION
This allows configuring what happens if there's a no space in the channel.

I also included some cleanups pointed out by clippy. These are separate commit, because they might move the needed version of rustc (but I think the shorthand initialization is there for some time already).