### PR TITLE
Alter location items passing - log 0.4 support

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -281,8 +281,15 @@ where
         let join = builder.spawn(move || loop {
             match rx.recv().unwrap() {
                 AsyncMsg::Record(r) => {
+                    let location = slog::RecordLocation {
+                        file: &*r.file,
+                        line: r.line,
+                        column: r.column,
+                        function: &*r.function,
+                        module: &*r.module,
+                    };
                     let rs = RecordStatic {
-                        location: &*r.location,
+                        location: &location,
                         level: r.level,
                         tag: &r.tag,
                     };
@@ -462,7 +469,11 @@ impl Drain for AsyncCore {
         self.send(AsyncRecord {
             msg: fmt::format(*record.msg()),
             level: record.level(),
-            location: Box::new(*record.location()),
+            file: String::from(record.file()),
+            line: record.line(),
+            column: record.column(),
+            function: String::from(record.function()),
+            module: String::from(record.module()),
             tag: String::from(record.tag()),
             logger_values: logger_values.clone(),
             kv: ser.finish(),
@@ -473,7 +484,11 @@ impl Drain for AsyncCore {
 struct AsyncRecord {
     msg: String,
     level: Level,
-    location: Box<slog::RecordLocation>,
+    file: String,
+    line: u32,
+    column: u32,
+    function: String,
+    module: String,
     tag: String,
     logger_values: OwnedKVList,
     kv: Box<KV + Send>,


### PR DESCRIPTION
Before log 0.4 location info (file, module) had 'static lifetime.
Now the lifetime is not required to be static, so these items are
now converted to owned values (String) when passed to async drain.