### PR TITLE
Replace the std mpsc channel with a crossbeam channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ path = "lib.rs"
 slog = "2.1"
 thread_local = "0.3.3"
 take_mut = "0.2.0"
+crossbeam-channel = "0.3"
 
 [package.metadata.docs.rs]
 features = ["nested-values", "dynamic-keys"]


### PR DESCRIPTION
Hi,

I have been performing a few benchmarks on a couple slog-based logging pipelines relying on the Async Drain and have seen significantly better throughput using crossbeam channels.

Crossbeam channels revealed to be as efficient as std ones with only 1 producing thread involved but showed between 60% and 80% higher throughput when increasing the number of producing threads to 4, regardless of the overflow strategy.

Would it be acceptable to drop the std channel implementation in favor of the crossbeam one?

These benchmarks aren't clean enough yet to be included in this PR but if you request it I will polish them and include them.