### PR TITLE
update to use crossbeam-channel == 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "lib.rs"
 slog = "2.1"
 thread_local = "1"
 take_mut = "0.2.0"
-crossbeam-channel = "0.4"
+crossbeam-channel = "0.5"
 
 [package.metadata.docs.rs]
 features = ["nested-values", "dynamic-keys"]


### PR DESCRIPTION
The [changelog](https://github.com/crossbeam-rs/crossbeam/blob/master/crossbeam-channel/CHANGELOG.md).
No breaking API, but I haven't check whether any of the new APIs should be used.