### PR TITLE
Fix top-level doctest

### DIFF
--- a/lib.rs
+++ b/lib.rs
@@ -30,9 +30,11 @@
 //! ```
 //! // ...
 //! fn main() {
-//!     let _exit_code = run(); // logger gets flushed as `run()` returns.
-//!     // std::process::exit(exit_code) // this needs to be commented or it'll
-//!                                      // end the doctest
+//!     let exit_code = run(); // logger gets flushed as `run()` returns.
+//! #   if false {
+//! #   // this must not run or it'll end the doctest
+//!     std::process::exit(exit_code)
+//! #   }
 //! }
 //!
 //! fn run() -> i32 {


### PR DESCRIPTION
The way the `std::process::exit` call in the top level doctest is currently commented out is somewhat confusing to readers (or at least does not flow well); this commit instead wraps it in a hidden `if false { ... }`, which will prevent it from running without affecting what the documentation looks like.