### PR TITLE
Replace crossbeam-channel by flume

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ path = "lib.rs"
 slog = "2.1"
 thread_local = "1"
 take_mut = "0.2.0"
-crossbeam-channel = "0.5"
+flume = "0.10.1"
 
 [package.metadata.docs.rs]
 features = ["nested-values", "dynamic-keys"]

--- a/lib.rs
+++ b/lib.rs
@@ -60,7 +60,6 @@ use slog::{BorrowedKV, Level, Record, RecordStatic, SingleKV, KV};
 use slog::{Key, OwnedKVList, Serializer};
 
 use slog::Drain;
-use std::error::Error;
 use std::fmt;
 use std::sync;
 use std::{io, thread};
@@ -210,7 +209,7 @@ impl<T> From<std::sync::PoisonError<T>> for AsyncError {
     fn from(err: std::sync::PoisonError<T>) -> AsyncError {
         AsyncError::Fatal(Box::new(io::Error::new(
             io::ErrorKind::BrokenPipe,
-            err.description(),
+            err.to_string(),
         )))
     }
 }


### PR DESCRIPTION
Replace `crossbeam-channel` by  [flume](https://github.com/zesterer/flume), which is coming with some advantages, see https://github.com/zesterer/flume#why-flume.


