### PR TITLE
Support u128/i128

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,53 @@
+use std::env;
+use std::process::Command;
+use std::str::{self, FromStr};
+
+// This build script is adapted from serde.
+// See https://github.com/serde-rs/serde/blob/9c39115f827170f7adbdfa4115f5916c5979393c/serde/build.rs
+fn main() {
+    let minor = match rustc_minor_version() {
+        Some(minor) => minor,
+        None => return,
+    };
+
+    let target = env::var("TARGET").unwrap();
+    let emscripten = target == "asmjs-unknown-emscripten" || target == "wasm32-unknown-emscripten";
+
+    // 128-bit integers stabilized in Rust 1.26:
+    // https://blog.rust-lang.org/2018/05/10/Rust-1.26.html
+    //
+    // Disabled on Emscripten targets as Emscripten doesn't
+    // currently support integers larger than 64 bits.
+    if minor >= 26 && !emscripten {
+        println!("cargo:rustc-cfg=integer128");
+    }
+}
+
+fn rustc_minor_version() -> Option<u32> {
+    let rustc = match env::var_os("RUSTC") {
+        Some(rustc) => rustc,
+        None => return None,
+    };
+
+    let output = match Command::new(rustc).arg("--version").output() {
+        Ok(output) => output,
+        Err(_) => return None,
+    };
+
+    let version = match str::from_utf8(&output.stdout) {
+        Ok(version) => version,
+        Err(_) => return None,
+    };
+
+    let mut pieces = version.split('.');
+    if pieces.next() != Some("rustc 1") {
+        return None;
+    }
+
+    let next = match pieces.next() {
+        Some(next) => next,
+        None => return None,
+    };
+
+    u32::from_str(next).ok()
+}

--- a/lib.rs
+++ b/lib.rs
@@ -144,6 +144,16 @@ impl Serializer for ToSendSerializer {
         take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
         Ok(())
     }
+    #[cfg(integer128)]
+    fn emit_u128(&mut self, key: Key, val: u128) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
+    #[cfg(integer128)]
+    fn emit_i128(&mut self, key: Key, val: i128) -> slog::Result {
+        take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
+        Ok(())
+    }
     fn emit_usize(&mut self, key: Key, val: usize) -> slog::Result {
         take(&mut self.kv, |kv| Box::new((kv, SingleKV(key, val))));
         Ok(())


### PR DESCRIPTION
Is the check for integer128 support still needed? It's supported since Rust 1.26.

Is it okay to have a dependency to serde just for [`serde::serde_if_integer128`](https://docs.serde.rs/serde/macro.serde_if_integer128.html)? Alternatives are to implement something similar in this crate, or provide it in "slog".