### PR TITLE
Avoid thread kill via panic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 2.8.0 - 2023-06-16
+
+* Call of deprecated `err.description()` replaced with `err.to_string()`.
+* Avoided all catchable panics in async drain thread.
+
 ## 2.7.0 - 2021-07-29
 
 * Fix license field to be a valid SPDX expression

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slog-async"
-version = "2.7.0"
+version = "2.8.0"
 authors = ["Dawid Ciężarkiewicz <dpc@dpc.pw>"]
 description = "Asynchronous drain for slog-rs"
 keywords = ["slog", "logging", "log", "asynchronous"]

--- a/lib.rs
+++ b/lib.rs
@@ -62,7 +62,6 @@ use slog::{BorrowedKV, Level, Record, RecordStatic, SingleKV, KV};
 use slog::{Key, OwnedKVList, Serializer};
 
 use slog::Drain;
-use std::error::Error;
 use std::fmt;
 use std::sync;
 use std::{io, thread};
@@ -222,7 +221,7 @@ impl<T> From<std::sync::PoisonError<T>> for AsyncError {
     fn from(err: std::sync::PoisonError<T>) -> AsyncError {
         AsyncError::Fatal(Box::new(io::Error::new(
             io::ErrorKind::BrokenPipe,
-            err.description(),
+            err.to_string(),
         )))
     }
 }


### PR DESCRIPTION
We have encountered a situation when the inner task of async drain had been killed with a panic due to lack of free space on the device. It would be great to see some useful infromation about this case when it happens and have the thread stopped more gracefully. Changes provided within this PR are intended to help with described issues.

`eprintln` is used to output information about encountered errors since the intended way of logging obviously doesn't work correctly in related cases.