### PR TITLE
Define Minimum Supported Rust Version, Setup Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,59 @@
+# We use `actions-rs` for most of our actions
+#
+# This file is for the main tests, it is based on test.yml in the main slog repo.
+# If we want to add clippy & rustfmt, they should be separate workflows.
+on: [push, pull_request]
+name: Cargo Test
+
+env:
+  CARGO_TERM_COLOR: always
+  # has a history of occasional bugs (especially on old versions)
+  #
+  # the ci is free so we might as well use it ;)
+  CARGO_INCREMENTAL: 0
+
+
+# Tested versions:
+# 1. stable
+# 2. nightly
+# 3. Minimum Supported Rust Version (MSRV)
+
+jobs:
+  test:
+    # Only run on PRs if the source branch is on someone else's repo
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false # Even if one job fails we still want to see the other ones
+      matrix:
+        # 1.59 is MSRV
+        rust: [1.59, stable, nightly]
+        # NOTE: Features to test must be specified manually. They are applied to all versions separately.
+        #
+        # This has the advantage of being more flexibile and thorough
+        # This has the disadvantage of being more vebrose
+        #
+        # Specific feature combos can be overridden per-version with 'include' and 'ecclude'
+        features: ["", "nested-values", "dynamic-keys", "nested-values dynamic-keys"]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: ${{ matrix.rust }}
+          override: true
+      - name: Check
+        # A failing `cargo check` always ends the build
+        run: |
+          cargo check --verbose --features "${{ matrix.features }}"
+        # A failing `cargo check` always fails the build
+        continue-on-error: false
+      - name: Test
+        run: |
+          cargo test --verbose --features "${{ matrix.features }}"
+
+        # NOTE: Upstream slog has a hack here for continue-on-error
+        #
+        # We don't appear to need it.
+        # continue-on-error: ${{ matrix.features == '' }} 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## 2.8.0 - 2023-06-16
+## [Unreleased]
+
+## 2.8.0 - 2023-08-26
 
 * Call of deprecated `err.description()` replaced with `err.to_string()`.
 * Avoided all catchable panics in async drain thread.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Call of deprecated `err.description()` replaced with `err.to_string()`.
 * Avoided all catchable panics in async drain thread.
+* Define minimum supported rust version.
 
 ## 2.7.0 - 2021-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Call of deprecated `err.description()` replaced with `err.to_string()`.
 * Avoided all catchable panics in async drain thread.
 * Define minimum supported rust version.
+* Setup Github Actions.
 
 ## 2.7.0 - 2021-07-29
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/slog-async"
 homepage = "https://github.com/slog-rs/slog"
 repository = "https://github.com/slog-rs/async"
 readme = "README.md"
+rust-version = "1.59.0"
 
 [features]
 nested-values = ["slog/nested-values"]


### PR DESCRIPTION
- Fixup changelog for 2.8.0 release
   - Keep `## [Unreleased]` section at the top, as recommended by https://keepachangelog.org/
- Define minimum supported rust version
- Define github actions workflow for tests

I want to merge this before publishing the 2.8.0 release.
